### PR TITLE
DEFAULT_MULTN: Increase multimaps to unlimited

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,13 +97,13 @@ impl StarReference {
 #[derive(Clone)]
 pub struct StarSettings {
     reference_path: String,
-    multn: usize,
+    multn: isize,
     args: Vec<String>,
 }
 
 /// Set the --outSAMmultNmax parameter of STAR.
 /// Max number of multiple alignments for a read that will be output to the SAM/BAM files.
-const DEFAULT_MULTN: usize = 10;
+const DEFAULT_MULTN: isize = -1;
 
 impl StarSettings {
     /// This constructor just sets all of the necessary arguments to their defaults, and the
@@ -148,7 +148,7 @@ impl StarSettings {
     }
 
     /// Set the max number of multimapping reads
-    pub fn set_multn(&mut self, new_multn: usize) {
+    pub fn set_multn(&mut self, new_multn: isize) {
         self.multn = new_multn;
         self.sync_args();
     }


### PR DESCRIPTION
Set the `--outSAMmultNmax=-1` parameter of STAR.

A different read will be selected by STAR as the primary alignment when `--outSAMmultNmax=-1` vs `--outSAMmultNmax=999999999`. This behaviour is unexpected to me, but there you are.

See https://github.com/10XGenomics/STAR/blob/2c17c9ce6bf25f606c4f7a843b703e0692a9fcf6/source/ReadAlign_multMapSelect.cpp#L86