### PR TITLE
star-sys/build.rs: Remove -fPIC and enable -Werror

### DIFF
--- a/star-sys/build.rs
+++ b/star-sys/build.rs
@@ -70,13 +70,12 @@ fn main() {
     cc::Build::new()
         .cpp(true)
         .static_flag(true)
-        .pic(true)
         .cpp_link_stdlib(Some(libcxx()))
         .define("COMPILATION_TIME_PLACE", "\"build.rs\"")
         .files(FILES)
         .flag("-std=c++11")
         .flag("-Wall")
         .flag("-Wextra")
-        .flag("-fPIC")
+        .flag("-Werror")
         .compile("orbit");
 }


### PR DESCRIPTION
~~Position independent code (PIC) is not needed for a static library, and non-PIC is more efficient than PIC.~~

Position independent code (PIC) is the default.

See https://docs.rs/cc/1.0.52/cc/struct.Build.html#method.pic