### PR TITLE
Add license declarations to Cargo.tomls.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "orbit"
 version = "0.2.0"
 authors = ["mkirsche", "Lance Hepler <lance.hepler@10xgenomics.com>", "Patrick Marks <patrick@10xgenomics.com>"]
 edition = "2018"
+license = "MIT"
 
 [workspace]
 

--- a/star-sys/Cargo.toml
+++ b/star-sys/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["mkirsche", "Lance Hepler <lance.hepler@10xgenomics.com>", "Patrick M
 edition = "2018"
 build = "build.rs"
 links = "star"
+license = "MIT"
 
 [lib]
 name = "star_sys"


### PR DESCRIPTION
Some tools, like `cargo deny`, complain if a crate doesn't declare a license (even if the repo does).