### PR TITLE
Exclude test files from crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.1"
 authors = ["mkirsche", "Lance Hepler <lance.hepler@10xgenomics.com>", "Patrick Marks <patrick@10xgenomics.com>"]
 edition = "2018"
 license = "MIT"
+include = ["wrapper.h", "src/lib.rs", "LICENSE", "README.md"]
 
 [workspace]
 


### PR DESCRIPTION
```
$ cargo diet
┌─────────────────────────────────────────────────┬─────────────┐
│ File                                            │ Size (Byte) │
├─────────────────────────────────────────────────┼─────────────┤
│ test/ercc92-1.2.0/star/sjdbList.out.tab         │           0 │
│ test/ercc92-1.2.0/star/sjdbList.fromGTF.out.tab │           0 │
│ test/ercc92-1.2.0/star/sjdbInfo.txt             │           6 │
│ .gitignore                                      │          20 │
│ test/ercc92-1.2.0/reference.json                │         365 │
│ test/ercc92-1.2.0/star/chrLength.txt            │         412 │
│ test/ercc92-1.2.0/star/chrStart.txt             │         557 │
│ test/ercc92-1.2.0/star/exonInfo.tab             │         783 │
│ test/ercc92-1.2.0/star/genomeParameters.txt     │         905 │
│ test/ercc92-1.2.0/star/chrName.txt              │        1012 │
│ test/ercc92-1.2.0/star/geneInfo.tab             │        1015 │
│ .github/workflows/test.yml                      │        1365 │
│ test/ercc92-1.2.0/star/chrNameLength.txt        │        1424 │
│ test/full1_sample.bam                           │        1719 │
│ test/ercc92-1.2.0/star/exonGeTrInfo.tab         │        1824 │
│ test/full1_sample.fastq                         │        1862 │
│ test/ercc92-1.2.0/star/transcriptInfo.tab       │        3307 │
│ test/ercc92-1.2.0/genes/genes.gtf               │        7956 │
│ test/ercc92-1.2.0/pickle/genes.pickle           │       29640 │
│ test/ercc92-1.2.0/fasta/genome.fa               │       85552 │
│ test/ercc92-1.2.0/star/SAindex                  │       95643 │
│ test/ercc92-1.2.0/star/Genome                   │      111104 │
│ test/test_ercc_reads.fastq                      │      501000 │
│ test/ercc92-1.2.0/star/SA                       │      682732 │
└─────────────────────────────────────────────────┴─────────────┘
Saved 98% or 1.5 MB in 24 files (of 1.6 MB and 29 files in entire crate)
```