### PR TITLE
Speed up stitchAlignToTranscript

### DIFF
--- a/star-sys/STAR/source/Transcript.cpp
+++ b/star-sys/STAR/source/Transcript.cpp
@@ -20,7 +20,7 @@ void Transcript::reset() {
     nMatch=0;
     nMM=0;
 
-    nGap=0; lGap=0; lDel=0; lIns=0; nDel=0; nIns=0;
+    nGap=0; lGap=0; lDel=0; lIns=0; nDel=0; nIns=0; nExons = 0;
 
     nUnique=nAnchor=0;
 };


### PR DESCRIPTION
Profiling seemed to show it spent most of its time allocating memory for `Transcript trExtend` and spending time
checking for splice junctions in an inefficient way.