### PR TITLE
Fix memory leaks in ReadAlign.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,7 @@ impl StarReference {
         let nvec = settings
             .args
             .iter()
-            .map(String::as_str)
-            .map(CString::new)
+            .map(|s| CString::new(s.as_str()))
             .collect::<Result<Vec<_>, _>>()?;
         let c_args = nvec.iter().map(|s| s.as_ptr()).collect::<Vec<_>>();
         let length = nvec.len() as c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,21 +47,16 @@ impl StarReference {
         let (header, header_view) = generate_header(&settings.reference_path);
 
         // Load reference
-        let mut nvec = Vec::new();
-        for x in settings.args.iter() {
-            let cur_string = CString::new(x.as_str())?;
-            nvec.push(cur_string.into_raw());
-        }
-
-        let c_args = nvec.as_mut_ptr() as *mut *mut c_char;
+        let nvec = settings
+            .args
+            .iter()
+            .map(String::as_str)
+            .map(CString::new)
+            .collect::<Result<Vec<_>, _>>()?;
+        let c_args = nvec.iter().map(|s| s.as_ptr()).collect::<Vec<_>>();
         let length = nvec.len() as c_int;
 
-        let reference = unsafe { bindings::init_star_ref(length, c_args) };
-
-        // recover stray CStrings to prevent leaked memory
-        nvec.into_iter().for_each(|ptr| unsafe {
-            drop(CString::from_raw(ptr));
-        });
+        let reference = unsafe { bindings::init_star_ref(length, c_args.as_ptr()) };
 
         let inner = InnerStarReference {
             reference,

--- a/star-sys/STAR/source/Genome.cpp
+++ b/star-sys/STAR/source/Genome.cpp
@@ -195,8 +195,8 @@ void Genome::genomeLoad(){//allocate and load Genome
     uint SAiInBytes=0;
     SAiInBytes += fstreamReadBig(SAiIn,(char*) &pGe.gSAindexNbases, sizeof(pGe.gSAindexNbases));
 
-    genomeSAindexStart = new uint[pGe.gSAindexNbases+1];
-    SAiInBytes += fstreamReadBig(SAiIn,(char*) genomeSAindexStart, sizeof(genomeSAindexStart[0])*(pGe.gSAindexNbases+1));
+    genomeSAindexStart.resize(pGe.gSAindexNbases+1);
+    SAiInBytes += fstreamReadBig(SAiIn,(char*) genomeSAindexStart.data(), sizeof(genomeSAindexStart[0])*genomeSAindexStart.size());
     nSAi=genomeSAindexStart[pGe.gSAindexNbases];
     P.inOut->logMain << "Read from SAindex: pGe.gSAindexNbases=" << pGe.gSAindexNbases <<"  nSAi="<< nSAi <<endl;
 
@@ -321,15 +321,15 @@ void Genome::genomeLoad(){//allocate and load Genome
         sjGstart=chrStart[sjChrStart];
 
         //fill the sj-db to genome translation array
-        sjDstart=new uint [sjdbN];
-        sjAstart=new uint [sjdbN];
-        sjdbStart=new uint [sjdbN];
-        sjdbEnd=new uint [sjdbN];
+        sjDstart.resize(sjdbN);
+        sjAstart.resize(sjdbN);
+        sjdbStart.resize(sjdbN);
+        sjdbEnd.resize(sjdbN);
 
-        sjdbMotif=new uint8 [sjdbN];
-        sjdbShiftLeft=new uint8 [sjdbN];
-        sjdbShiftRight=new uint8 [sjdbN];
-        sjdbStrand=new uint8 [sjdbN];
+        sjdbMotif.resize(sjdbN);
+        sjdbShiftLeft.resize(sjdbN);
+        sjdbShiftRight.resize(sjdbN);
+        sjdbStrand.resize(sjdbN);
 
         for (uint ii=0;ii<sjdbN;ii++) {//get the info about junctions from sjdbInfo.txt
             {
@@ -451,8 +451,8 @@ void Genome::chrInfoLoad() {//find chrStart,Length,nChr from Genome G
 
 //////////////////////////////////////////////////////////
 void Genome::chrBinFill() {
-    chrBinN = chrStart[nChrReal]/genomeChrBinNbases+1;
-    chrBin = new uint [chrBinN];
+    size_t chrBinN = chrStart[nChrReal]/genomeChrBinNbases+1;
+    chrBin.resize(chrBinN);
     for (uint ii=0, ichr=1; ii<chrBinN; ++ii) {
         if (ii*genomeChrBinNbases>=chrStart[ichr]) ichr++;
         chrBin[ii]=ichr-1;

--- a/star-sys/STAR/source/Genome.h
+++ b/star-sys/STAR/source/Genome.h
@@ -19,11 +19,12 @@ class Genome {
 
         //chr parameters
         vector <uint> chrStart, chrLength, chrLengthAll;
-        uint genomeChrBinNbases, chrBinN, *chrBin;
+        uint genomeChrBinNbases;
+        vector<uint> chrBin;
         vector <string> chrName, chrNameAll;
         map <string,uint> chrNameIndex;
 
-        uint *genomeSAindexStart;//starts of the L-mer indices in the SAindex, 1<=L<=pGe.gSAindexNbases
+        vector<uint> genomeSAindexStart;//starts of the L-mer indices in the SAindex, 1<=L<=pGe.gSAindexNbases
 
         uint nGenome, nSA, nSAbyte, nChrReal;//genome length, SA length, # of chromosomes, vector of chromosome start loci
         uint nGenome2, nSA2, nSAbyte2, nChrReal2; //same for the 2nd pass
@@ -35,10 +36,10 @@ class Genome {
         uint sjdbOverhang, sjdbLength; //length of the donor/acceptor, length of the sj "chromosome" =2*pGe.sjdbOverhang+1 including spacer
         uint sjChrStart,sjdbN; //first sj-db chr
         uint sjGstart; //start of the sj-db genome sequence
-        uint *sjDstart,*sjAstart,*sjStr, *sjdbStart, *sjdbEnd; //sjdb loci
-        uint8 *sjdbMotif; //motifs of annotated junctions
-        uint8 *sjdbShiftLeft, *sjdbShiftRight; //shifts of junctions
-        uint8 *sjdbStrand; //junctions strand, not used yet
+        vector<uint> sjDstart,sjAstart,sjStr, sjdbStart, sjdbEnd; //sjdb loci
+        vector<uint8> sjdbMotif; //motifs of annotated junctions
+        vector<uint8> sjdbShiftLeft, sjdbShiftRight; //shifts of junctions
+        vector<uint8> sjdbStrand; //junctions strand, not used yet
 
        //sequence insert parameters
         uint genomeInsertL; //total length of the sequence to be inserted on the fly

--- a/star-sys/STAR/source/Genome_genomeGenerate.cpp
+++ b/star-sys/STAR/source/Genome_genomeGenerate.cpp
@@ -506,7 +506,7 @@ void Genome::genomeGenerate() {
     ofstream & SAiOut = ofstrOpen(pGe.gDir+"/SAindex",ERROR_OUT, P);
 
     fstreamWriteBig(SAiOut, (char*) &pGe.gSAindexNbases, sizeof(pGe.gSAindexNbases),pGe.gDir+"/SAindex",ERROR_OUT,P);
-    fstreamWriteBig(SAiOut, (char*) genomeSAindexStart, sizeof(genomeSAindexStart[0])*(pGe.gSAindexNbases+1),pGe.gDir+"/SAindex",ERROR_OUT,P);
+    fstreamWriteBig(SAiOut, (char*) genomeSAindexStart.data(), sizeof(genomeSAindexStart[0])*(pGe.gSAindexNbases+1),pGe.gDir+"/SAindex",ERROR_OUT,P);
     fstreamWriteBig(SAiOut,  SAi.charArray, SAi.lengthByte,pGe.gDir+"/SAindex",ERROR_OUT,P);
     SAiOut.close();
 

--- a/star-sys/STAR/source/Parameters.cpp
+++ b/star-sys/STAR/source/Parameters.cpp
@@ -277,7 +277,7 @@ Parameters::~Parameters() {
 }
 
 
-void Parameters::inputParameters (int argInN, char* argIn[]) {//input parameters: default, from files, from command line
+void Parameters::inputParameters (int argInN, const char* const argIn[]) {//input parameters: default, from files, from command line
 
 ///////// Default parameters
     #include "parametersDefault.xxd"

--- a/star-sys/STAR/source/Parameters.h
+++ b/star-sys/STAR/source/Parameters.h
@@ -332,7 +332,7 @@ class Parameters {
     int readPars(); // read parameters from all files
     int scanOneLine (string &lineIn, int inputLevel, int inputLevelRequested);
     void scanAllLines (istream &streamIn, int inputLevel, int inputLevelRequested);
-    void inputParameters (int argInN, char* argIn[]); //input parameters: default, from files, from command line
+    void inputParameters (int argInN, const char* const argIn[]); //input parameters: default, from files, from command line
     void openReadsFiles();
     void closeReadsFiles();
     void readSAMheader(const string readFilesCommandString, const vector<string> readFilesNames);

--- a/star-sys/STAR/source/ReadAlign_chimericDetectionOldOutput.cpp
+++ b/star-sys/STAR/source/ReadAlign_chimericDetectionOldOutput.cpp
@@ -141,14 +141,14 @@ void ReadAlign::chimericDetectionOldOutput() {
 
     if (P.pCh.out.junctions) {
         //junction + SAMp
-        *chunkOutChimJunction << mapGen.chrName[trChim[0].Chr] <<"\t"<< chimJ0 - mapGen.chrStart[trChim[0].Chr]+1 <<"\t"<< (trChim[0].Str==0 ? "+":"-") \
+        chunkOutChimJunction << mapGen.chrName[trChim[0].Chr] <<"\t"<< chimJ0 - mapGen.chrStart[trChim[0].Chr]+1 <<"\t"<< (trChim[0].Str==0 ? "+":"-") \
                 <<"\t"<< mapGen.chrName[trChim[1].Chr] <<"\t"<< chimJ1 - mapGen.chrStart[trChim[1].Chr]+1 <<"\t"<< (trChim[1].Str==0 ? "+":"-") \
                 <<"\t"<< chimMotif <<"\t"<< chimRepeat0  <<"\t"<< chimRepeat1 <<"\t"<< readName+1 \
                 <<"\t"<< trChim[0].exons[0][EX_G] - mapGen.chrStart[trChim[0].Chr]+1 <<"\t"<< outputTranscriptCIGARp(trChim[0]) \
                 <<"\t"<< trChim[1].exons[0][EX_G] - mapGen.chrStart[trChim[1].Chr]+1 <<"\t"<<  outputTranscriptCIGARp(trChim[1]);
         if (P.outSAMattrPresent.RG)
-            *chunkOutChimJunction <<"\t"<< P.outSAMattrRG.at(readFilesIndex);
-        *chunkOutChimJunction <<"\n"; //<<"\t"<< trChim[0].exons[0][EX_iFrag]+1 --- no need for that, since trChim[0] is always on the first mate
+            chunkOutChimJunction <<"\t"<< P.outSAMattrRG.at(readFilesIndex);
+        chunkOutChimJunction <<"\n"; //<<"\t"<< trChim[0].exons[0][EX_iFrag]+1 --- no need for that, since trChim[0] is always on the first mate
     };
 
     return;

--- a/star-sys/STAR/source/ReadAlign_createExtendWindowsWithAlign.cpp
+++ b/star-sys/STAR/source/ReadAlign_createExtendWindowsWithAlign.cpp
@@ -8,7 +8,7 @@ int ReadAlign::createExtendWindowsWithAlign(uint a1, uint aStr) {
 
     uint aBin = (a1 >> P.winBinNbits); //align's bin
     uint iBinLeft=aBin, iBinRight=aBin;
-    uintWinBin* wB=winBin[aStr];
+    uintWinBin* wB=winBin[aStr].get();
     uint iBin=-1, iWin=-1, iWinRight=-1;
 
     if (wB[aBin]==uintWinBinMax) {//proceed if there is no window at this bin

--- a/star-sys/STAR/source/ReadAlign_mapOneRead.cpp
+++ b/star-sys/STAR/source/ReadAlign_mapOneRead.cpp
@@ -39,7 +39,7 @@ int ReadAlign::mapOneRead() {
     trInit->readNmates=readNmates;
     trInit->readName=readName;
 
-    trBest=trInit;
+    trBest=trInit.get();
 
     uint seedSearchStartLmax=min(P.seedSearchStartLmax, // 50
                                   (uint) (P.seedSearchStartLmaxOverLread*(Lread-1))); // read length
@@ -114,7 +114,7 @@ int ReadAlign::mapOneRead() {
     } else if (Nsplit>0 && nA>0) {//otherwise there are no good pieces, or all pieces map too many times: read cannot be mapped
 //         qsort((void*) PC, nP, sizeof(uint)*PC_SIZE, funCompareUint2);//sort PC by rStart and length
         //printf("stitching\n");
-        stitchPieces(Read1, Lread);
+        stitchPieces(Read1.data(), Lread);
         
     };
 

--- a/star-sys/STAR/source/ReadAlign_maxMappableLength2strands.cpp
+++ b/star-sys/STAR/source/ReadAlign_maxMappableLength2strands.cpp
@@ -86,14 +86,14 @@ uint ReadAlign::maxMappableLength2strands(uint pieceStartIn, uint pieceLengthIn,
             indStartEnd[0]=indStartEnd[1]=iSA1;
             Nrep=1;
             bool comparRes;
-            maxL=compareSeqToGenome(mapGen, Read1, pieceStart, pieceLength, Lind, iSA1, dirR, comparRes);
+            maxL=compareSeqToGenome(mapGen, Read1.data(), pieceStart, pieceLength, Lind, iSA1, dirR, comparRes);
         } else {//need SA search, pieceLength>maxL
             if (iSA2good && iSA1noN) {
                 maxL = Lind; //Lind bases were already matched
             } else {
                 maxL=0;
             };        
-            Nrep = maxMappableLength(mapGen, Read1, pieceStart, pieceLength, iSA1 & mapGen.SAiMarkNmask, iSA2, dirR, maxL, indStartEnd);
+            Nrep = maxMappableLength(mapGen, Read1.data(), pieceStart, pieceLength, iSA1 & mapGen.SAiMarkNmask, iSA2, dirR, maxL, indStartEnd);
         };
     #endif
 

--- a/star-sys/STAR/source/ReadAlign_outputAlignments.cpp
+++ b/star-sys/STAR/source/ReadAlign_outputAlignments.cpp
@@ -136,7 +136,7 @@ const char* ReadAlign::outputAlignments() {
 
             //transcripts
             if ( P.quant.trSAM.yes ) {//NOTE: the transcripts are changed by this function (soft-clipping extended), cannot be reused
-                quantTranscriptome(chunkTr, nTrOut, trMult,  alignTrAll, readTranscripts, readGene);
+                quantTranscriptome(chunkTr, nTrOut, trMult,  alignTrAll.get(), readTranscripts, readGene);
             };
 
         };

--- a/star-sys/STAR/source/ReadAlign_stitchPieces.cpp
+++ b/star-sys/STAR/source/ReadAlign_stitchPieces.cpp
@@ -13,8 +13,8 @@
 void ReadAlign::stitchPieces(char **R, uint Lread) {
 
     //zero-out winBin
-    memset(winBin[0],255,sizeof(winBin[0][0])*P.winBinN);
-    memset(winBin[1],255,sizeof(winBin[0][0])*P.winBinN);
+    memset(winBin[0].get(),255,sizeof(winBin[0][0])*P.winBinN);
+    memset(winBin[1].get(),255,sizeof(winBin[0][0])*P.winBinN);
 
 //     for (uint iWin=0;iWin<nWall;iWin++) {//zero out winBin
 //         if (WC[iWin][WC_gStart]<=WC[iWin][WC_gEnd]) {//otherwise the window is dead
@@ -265,7 +265,7 @@ std::time(&timeStart);
         return;
     #endif
     //generate transcript for each window, choose the best
-    trBest =trInit; //initialize next/best
+    trBest =trInit.get(); //initialize next/best
     uint iW1=0;//index of non-empty windows
     uint trNtotal=0; //total number of recorded transcripts
 
@@ -290,7 +290,7 @@ std::time(&timeStart);
         trA.roStr = revertStrand ? 1-trA.Str : trA.Str; //original strand of the read
         trA.maxScore=0;
         //printf("something something trAll %llu\n", trNtotal);
-        trAll[iW1]=trArrayPointer+trNtotal;
+        trAll[iW1]=trArrayPointer.get()+trNtotal;
         if (trNtotal+P.alignTranscriptsPerWindowNmax >= P.alignTranscriptsPerReadNmax) {
             P.inOut->logMain << "WARNING: not enough space allocated for transcript. Did not process all windows for read "<< readName+1 <<endl;
             P.inOut->logMain <<"   SOLUTION: increase alignTranscriptsPerReadNmax and re-run\n" << flush;
@@ -323,7 +323,7 @@ std::time(&timeStart);
             stitchWindowSeeds(iW, iW1, WAincl, R[trA.roStr==0 ? 0:2]);
         };
     #else
-        stitchWindowAligns(0, nWA[iW], 0, WAincl, 0, 0, trA, Lread, WA[iW], R[trA.roStr==0 ? 0:2], mapGen, P, trAll[iW1], nWinTr+iW1, this);
+        stitchWindowAligns(0, nWA[iW], 0, WAincl.get(), 0, 0, trA, Lread, WA[iW].get(), R[trA.roStr==0 ? 0:2], mapGen, P, trAll[iW1], nWinTr.get()+iW1, this);
     #endif
         if (nWinTr[iW1]==0) {
             continue;

--- a/star-sys/STAR/source/SequenceFuns.cpp
+++ b/star-sys/STAR/source/SequenceFuns.cpp
@@ -317,7 +317,7 @@ uint localSearchNisMM(const char *x, uint nx, const char *y, uint ny, double pMM
 
 
 
-uint qualitySplit(char* r, char* q, uint L, char Qsplit, uint maxNsplit, uint  minLsplit, uint** splitR) {
+uint qualitySplit(char* r, char* q, uint L, char Qsplit, uint maxNsplit, uint  minLsplit, std::array<vector<uint>, 3>& splitR) {
     //splits the read r[L] by quality scores q[L], outputs in splitR - split coordinate/length - per base
     //returns number of good split regions
     uint iR=0,iS=0,iR1,LgoodMin=0, iFrag=0;

--- a/star-sys/STAR/source/SequenceFuns.h
+++ b/star-sys/STAR/source/SequenceFuns.h
@@ -19,7 +19,7 @@ uint chrFind(uint, uint, uint*); // find chromosome from global locus
 uint localSearch(const char*, uint, const char*, uint, double); //local search to clip adapter
 uint localSearchNisMM(const char *x, uint nx, const char *y, uint ny, double pMM);
 
-uint qualitySplit(char*, char*, uint, char, uint, uint, uint**);
+uint qualitySplit(char*, char*, uint, char, uint, uint, std::array<std::vector<uint>, 3>&);
 
 int32 convertNuclStrToInt32(const string S, uint32 &intOut);
 string convertNuclInt32toString(const uint32 nuclNum, const uint32 L);

--- a/star-sys/STAR/source/Transcript.h
+++ b/star-sys/STAR/source/Transcript.h
@@ -24,7 +24,7 @@ public:
     uint Lread, readLengthPairOriginal;
     uint iRead; //read identifier
     uint readNmates;
-    char *readName;
+    char const *readName;
 
     int iFrag; //frag number of the transcript, if the the transcript contains only one frag
 

--- a/star-sys/STAR/source/genomeSAindex.cpp
+++ b/star-sys/STAR/source/genomeSAindex.cpp
@@ -5,7 +5,7 @@
 
 void genomeSAindex(char * G, PackedArray & SA, Parameters & P, PackedArray & SAi, Genome &mapGen)
  {
-    mapGen.genomeSAindexStart = new uint [mapGen.pGe.gSAindexNbases+1];
+    mapGen.genomeSAindexStart.resize(mapGen.pGe.gSAindexNbases+1);
     mapGen.genomeSAindexStart[0]=0;
     for (uint ii=1;ii<=mapGen.pGe.gSAindexNbases;ii++) {//L-mer indices starts
         mapGen.genomeSAindexStart[ii] = mapGen.genomeSAindexStart[ii-1] + ( 1LLU<<(2*ii) );

--- a/star-sys/STAR/source/orbit.h
+++ b/star-sys/STAR/source/orbit.h
@@ -30,10 +30,10 @@ extern "C" {
 
     // init_aligner: initialize an aligner given the array of parameters which
     // would be passed to STAR
-    struct Aligner* init_aligner(int, char*[]);
+    struct Aligner* init_aligner(int, const char* const[]);
 
     // init_star_ref: build a star reference with a given set of arguments
-    const struct StarRef* init_star_ref(int, char*[]);
+    const struct StarRef* init_star_ref(int, const char* const[]);
 
     // init_aligner_from_ref takes a StarRef struct with an already built
     // genome and builds an aligner around it

--- a/star-sys/STAR/source/stitchAlignToTranscript.cpp
+++ b/star-sys/STAR/source/stitchAlignToTranscript.cpp
@@ -197,7 +197,7 @@ intScore stitchAlignToTranscript(uint rAend, uint gAend, uint rBstart, uint gBst
                 //score the gap
                 if (mapGen.sjdbN>0) {//check if the junction is annotated
                         uint jS=gAend+jR+1, jE=gBstart1+jR;//intron start/end
-                        int sjdbInd=binarySearch2(jS,jE,mapGen.sjdbStart,mapGen.sjdbEnd,mapGen.sjdbN);
+                        int sjdbInd=binarySearch2(jS,jE,mapGen.sjdbStart.data(),mapGen.sjdbEnd.data(),mapGen.sjdbN);
                         if (sjdbInd<0) {
                             if (Del>=P.alignIntronMin) {
                                 Score += P.scoreGap + jPen; //genome gap penalty + non-canonical penalty

--- a/star-sys/build.rs
+++ b/star-sys/build.rs
@@ -123,7 +123,7 @@ fn main() {
         .cpp_link_stdlib(Some(libcxx()))
         .define("COMPILATION_TIME_PLACE", "\"build.rs\"")
         .files(FILES)
-        .flag("-std=c++11")
+        .flag("-std=c++17")
         .flag("-Wall")
         .flag("-Wextra")
         .flag("-Werror")

--- a/star-sys/src/lib.rs
+++ b/star-sys/src/lib.rs
@@ -29,7 +29,7 @@ extern "C" {
 extern "C" {
     pub fn init_star_ref(
         arg1: ::std::os::raw::c_int,
-        arg2: *mut *mut ::std::os::raw::c_char,
+        arg2: *const *const ::std::os::raw::c_char,
     ) -> *const StarRef;
 }
 extern "C" {


### PR DESCRIPTION
Use unique_ptr to manage memory in ReadAlign and orbit front-end.  Try to do this in a minimally-invasive way so we don't have to touch too much other code.

Take a few things that shouldn't have been pointers and make them not be pointers.

Slab-allocate the storage for some arrays-of-arrays.

Make argv parameters const, for both the c++ side and the rust side. Clean up memory management for C strings on the rust side.