### PR TITLE
star-sys: Include std::array

### DIFF
--- a/star-sys/STAR/source/SequenceFuns.cpp
+++ b/star-sys/STAR/source/SequenceFuns.cpp
@@ -1,5 +1,7 @@
 #include "SequenceFuns.h"
 
+#include <array>
+
 void complementSeqNumbers(char* ReadsIn, char* ReadsOut, uint Lread) {//complement the numeric sequences
     for (uint jj=0;jj<Lread;jj++) {
         switch (int(ReadsIn[jj])){


### PR DESCRIPTION
Fix `error: implicit instantiation of undefined template 'std::array<std::vector<unsigned long long>, 3>'` observed on macOS using `clang++`.
