### PR TITLE
star-sys: Build with `_LIBCPP_REMOVE_TRANSITIVE_INCLUDES`

### DIFF
--- a/star-sys/build.rs
+++ b/star-sys/build.rs
@@ -122,6 +122,7 @@ fn main() {
         .cpp(true)
         .cpp_link_stdlib(Some(libcxx()))
         .define("COMPILATION_TIME_PLACE", "\"build.rs\"")
+        .define("_LIBCPP_REMOVE_TRANSITIVE_INCLUDES", None)
         .files(FILES)
         .flag("-std=c++17")
         .flag("-Wall")


### PR DESCRIPTION
As proposed in https://github.com/10XGenomics/orbit/pull/50, appears to build cleanly already. 