### PR TITLE
gh-actions: Upgrade test workflow to `ubuntu-20.04`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   rust:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout git repository
         uses: actions/checkout@master


### PR DESCRIPTION
Github has deprecated `ubuntu-18.04`, so move to a supported image version.