### PR TITLE
Widen version range for rust-htslib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ libc = "0.2"
 star-sys = { version = "0.2", path = "star-sys" }
 
 [dependencies.rust-htslib]
-version = ">=0.38.2, <0.41"
+version = ">=0.38.2, <0.42"
 default-features = false
 features = ["serde_feature"]
 


### PR DESCRIPTION
Allow 0.41.