### PR TITLE
Fix clang: error: unknown argument: '-mcmpxchg16b'

### DIFF
--- a/star-sys/build.rs
+++ b/star-sys/build.rs
@@ -146,7 +146,9 @@ fn main() {
     if cfg!(target_feature = "popcnt") {
         build.flag("-mpopcnt");
     }
-    if cfg!(target_feature = "cmpxchg16b") {
+    if cfg!(target_feature = "cmpxchg16b") && !cfg!(target_os = "macos") {
+        // Apple clang version 14.0.0 does not support -mcmpxchg16b.
+        // Fix the error: cargo:warning=clang: error: unknown argument: '-mcmpxchg16b'
         build.flag("-mcmpxchg16b");
     }
     if cfg!(target_feature = "fma4") {


### PR DESCRIPTION
Apple clang version 14.0.0 does not support `-mcmpxchg16b`.

It'd probably be better to check the precise version of `clang++` or check for compiler support some other way, but this fix works for now.

Fix the error:

```console
$ uname -a
Darwin fpx-l-amer01854 21.6.0 Darwin Kernel Version 21.6.0: Thu Mar  9 20:08:59 PST 2023; root:xnu-8020.240.18.700.8~1/RELEASE_X86_64 x86_64
$ clang++ --version
Apple clang version 14.0.0 (clang-1400.0.29.202)
Target: x86_64-apple-darwin21.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
$ cargo check
…
CARGO_CFG_TARGET_FEATURE = Some("cmpxchg16b,fxsr,sse,sse2,sse3,ssse3")
…
cargo:warning=clang: error: unknown argument: '-mcmpxchg16b'
…
error occurred: Command "c++" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "-m64" "-arch" "x86_64" "-Wall" "-Wextra" "-std=c++17" "-Wall" "-Wextra" "-Werror" "-fvisibility=hidden" "-msse3" "-mssse3" "-mcmpxchg16b" "-DCOMPILATION_TIME_PLACE=\"build.rs\"" "-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES" "-o" "/Users/shaun.jackman/work/cellranger/lib/rust/target/debug/build/star-sys-7572b76e8aea02fb/out/STAR/source/orbit.o" "-c" "STAR/source/orbit.cpp" with args "c++" did not execute successfully (status code exit status: 1).
…
```
