### PR TITLE
chore: fix STAR warningns coming from clang 18

### DIFF
--- a/star-sys/STAR/source/ReadAlign_maxMappableLength2strands.cpp
+++ b/star-sys/STAR/source/ReadAlign_maxMappableLength2strands.cpp
@@ -1,12 +1,20 @@
+#include <array>
+#include <vector>
+
 #include "ReadAlign.h"
 #include "SuffixArrayFuns.h"
 #include "ErrorWarning.h"
+
+using std::array;
+using std::vector;
 
 uint ReadAlign::maxMappableLength2strands(uint pieceStartIn, uint pieceLengthIn, uint iDir, uint iSA1, uint iSA2, uint& maxLbest, uint iFrag) {
     //returns number of mappings, maxMappedLength=mapped length
     uint Nrep=0, indStartEnd[2], maxL;
 
-    uint NrepAll[P.pGe.gSAsparseD], indStartEndAll[P.pGe.gSAsparseD][2], maxLall[P.pGe.gSAsparseD];
+    vector<uint> NrepAll(P.pGe.gSAsparseD);
+    vector<array<uint, 2>> indStartEndAll(P.pGe.gSAsparseD);
+    vector<uint> maxLall(P.pGe.gSAsparseD);
     maxLbest=0;
 
     bool dirR = iDir==0;
@@ -108,7 +116,7 @@ uint ReadAlign::maxMappableLength2strands(uint pieceStartIn, uint pieceLengthIn,
 
     for (uint iDist=0; iDist<min(pieceLengthIn,P.pGe.gSAsparseD); iDist++) {//cycle through different distances, store the ones with largest maxL
         if ( (maxLall[iDist]+iDist) == maxLbest) {
-            storeAligns(iDir, (dirR ? pieceStartIn+iDist : pieceStartIn-iDist), NrepAll[iDist], maxLall[iDist], indStartEndAll[iDist], iFrag);
+            storeAligns(iDir, (dirR ? pieceStartIn+iDist : pieceStartIn-iDist), NrepAll[iDist], maxLall[iDist], indStartEndAll[iDist].data(), iFrag);
         };
     };
     return Nrep;


### PR DESCRIPTION
Variable-length arrays are not part of standard c++.