### PR TITLE
feat: Replace Arc with Rc to fix clippy lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@ use std::io::prelude::*;
 use std::io::BufReader;
 use std::os::raw::{c_char, c_int};
 use std::path::Path;
-use std::sync::Arc;
+use std::rc::Rc;
 
 pub struct StarReference {
-    inner: Arc<InnerStarReference>,
+    inner: Rc<InnerStarReference>,
 }
 
 struct InnerStarReference {
@@ -23,8 +23,6 @@ struct InnerStarReference {
     header: Header,
     header_view: HeaderView,
 }
-
-unsafe impl Sync for InnerStarReference {}
 
 impl Drop for InnerStarReference {
     fn drop(&mut self) {
@@ -63,7 +61,7 @@ impl StarReference {
         };
 
         Ok(StarReference {
-            inner: Arc::new(inner),
+            inner: Rc::new(inner),
         })
     }
 
@@ -149,7 +147,7 @@ impl StarSettings {
 /// rust_htslib Record objects
 pub struct StarAligner {
     aligner: *mut BindAligner,
-    reference: Arc<InnerStarReference>,
+    reference: Rc<InnerStarReference>,
     sam_buf: Vec<u8>,
     aln_buf: Vec<u8>,
     fastq1: Vec<u8>,
@@ -165,7 +163,7 @@ enum AlignedRecords<'a> {
 }
 
 impl StarAligner {
-    fn new(reference: Arc<InnerStarReference>) -> StarAligner {
+    fn new(reference: Rc<InnerStarReference>) -> StarAligner {
         let aligner = unsafe { bindings::init_aligner_from_ref(reference.as_ref().reference) };
         let header_view = reference.as_ref().header_view.clone();
 

--- a/star-sys/src/lib.rs
+++ b/star-sys/src/lib.rs
@@ -6,8 +6,6 @@ pub struct StarRef {
     _unused: [u8; 0],
 }
 
-unsafe impl Send for StarRef {}
-
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Aligner {


### PR DESCRIPTION
- Replace `Arc` with `Rc` in `StarReference`
- Remove unused `unsafe impl Sync for InnerStarReference` and `unsafe impl Send for StarRef`
- Needed to bump `RUST_VERSION` from 1.65.0 to 1.79.0

The `StarReference` containing the `Rc` is cloned in the main thread, the clone is sent to the worker thread, and the worker thread returns the clone back to the main thread, which destructs it and its `Rc`, so a `Rc` is sufficient and an `Arc` is not needed.
https://github.com/10XDev/cellranger/blob/ca2035689090380a46c3f19b9f5a32a375e111c4/lib/rust/cr_lib/src/stages/align_and_count.rs#L814

Fix the clippy lint:

```
Error: error: usage of an `Arc` that is not `Send` and `Sync`
  --> src/lib.rs:66:20
   |
66 |             inner: Arc::new(inner),
   |                    ^^^^^^^^^^^^^^^
   |
   = note: `Arc<InnerStarReference>` is not `Send` and `Sync` as `InnerStarReference` is not `Send`
   = help: if the `Arc` will not used be across threads replace it with an `Rc`
   = help: otherwise make `InnerStarReference` `Send` and `Sync` or consider a wrapper type such as `Mutex`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
   = note: `-D clippy::arc-with-non-send-sync` implied by `-D clippy::suspicious`
   = help: to override `-D clippy::suspicious` add `#[allow(clippy::arc_with_non_send_sync)]`
```

See https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
