### PR TITLE
feat: impl Send for InnerStarReference for clippy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ struct InnerStarReference {
     header_view: HeaderView,
 }
 
+unsafe impl Send for InnerStarReference {}
 unsafe impl Sync for InnerStarReference {}
 
 impl Drop for InnerStarReference {

--- a/star-sys/src/lib.rs
+++ b/star-sys/src/lib.rs
@@ -6,8 +6,6 @@ pub struct StarRef {
     _unused: [u8; 0],
 }
 
-unsafe impl Send for StarRef {}
-
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Aligner {


### PR DESCRIPTION
- `impl Send for InnerStarReference` to fix the clippy lint:
  ```
  Error: error: usage of an `Arc` that is not `Send` and `Sync`
  ```
- Remove unused `impl Send for StarRef`
- Needed to bump `RUST_VERSION` from 1.65.0 to 1.79.0

Fix the clippy lint:

```
Error: error: usage of an `Arc` that is not `Send` and `Sync`
  --> src/lib.rs:66:20
   |
66 |             inner: Arc::new(inner),
   |                    ^^^^^^^^^^^^^^^
   |
   = note: `Arc<InnerStarReference>` is not `Send` and `Sync` as `InnerStarReference` is not `Send`
   = help: if the `Arc` will not used be across threads replace it with an `Rc`
   = help: otherwise make `InnerStarReference` `Send` and `Sync` or consider a wrapper type such as `Mutex`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
   = note: `-D clippy::arc-with-non-send-sync` implied by `-D clippy::suspicious`
   = help: to override `-D clippy::suspicious` add `#[allow(clippy::arc_with_non_send_sync)]`
```

See <https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync>
