### PR TITLE
chore(gha): Update Rust job to use ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   rust:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout git repository
         uses: actions/checkout@master


### PR DESCRIPTION
ubuntu-20.04 is no longer an available runner
This causes the associated GHA to wait for a runner that will never be provisioned (e.g. https://github.com/10XGenomics/orbit/actions/runs/17280571380/job/49047883909)

Caused by runner offering change: https://github.com/actions/runner-images/issues/11101